### PR TITLE
Comentrio de GitIgnore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 /Ecommerce/target/
 
 # NO BORRAR ESTE YA QUE CUENTA CON INFO SENSIBLE
+
+# El archivo de credenciales debe encontrarse en la direccion de la siguiente linea
 /EcommercePersistencia/src/main/resources/config.properties
 /EcommercePersistencia/target/
 /EcommercePersistencia/nbproject/


### PR DESCRIPTION
Solamente se agrego un comentario al gitIgnore, para saber en que direccion se encuentra el config.properties